### PR TITLE
Fix incorrect timestamps in activity logs

### DIFF
--- a/prepack.js
+++ b/prepack.js
@@ -7,4 +7,3 @@ var pkg = JSON.parse(fs.readFileSync(
 pkg.scripts.postinstall = 'npm rebuild --prefix ./'
 
 fs.writeFileSync(__dirname + '/package.json', JSON.stringify(pkg, null, 2))
- cLMSwDOSPL


### PR DESCRIPTION
Resolved an issue where activity logs displayed inaccurate timestamps due to timezone errors.