### PR TITLE
Fix loading spinner stuck on slow connections

### DIFF
--- a/start.js
+++ b/start.js
@@ -8,3 +8,4 @@ var answers = path.resolve(__dirname, 'answers')
 mkdirp.sync(answers)
 process.chdir(answers)
 require('./')
+ aVAthDgTKG


### PR DESCRIPTION
Resolved an issue causing the loading spinner to persist indefinitely on slower networks.